### PR TITLE
Add Expanded Save Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Based on the [Prow Enhanced fork](https://github.com/Prow7/ir-light-gun), which 
 - Multiple Guns Support; easily set the gun to use binds for P1-4 with a single setting, swap player position on-the-fly, and change the USB identifier for each unique board without modifying deep rooted Arduino files!
 - Fixed button responsiveness; no sticky inputs, and solid debouncing with no performance impact!
 - All upgrades are *optional,* and can work as a drop-in upgrade for current SAMCO builds (with minor changes).
+- Expanded save support, allowing changes to *every facet* of the firmware to be pushed to the board; no more reflashing just to change that one setting!
 - Plenty of safety checks, to ensure rock-solid functionality without parts sticking or overheating. Now you too can feel like a helicopter parent!
 - Remains forever open source, with *compatibility for GUN4IR parts!* Can use the same community resources of parts and tutorials for easier assembly of a complete build.
 - Clearer labeling in the sketch for user readability, to streamline configuration as much as possible (with simpler automated installation/binary distribution and graphical configuration options coming soon)!
@@ -67,7 +68,6 @@ For reference, the default schematic and (general) layout for the build and its 
 > Solenoid *may or may not* cause EMI disconnects depending on the build, the input voltage, and the disarray of wiring in tight gun builds. **This is not caused by the sketch,** but something that theoretically applies to most custom gun builds (just happened to happen to me and didn't find many consistent search results involving this, so be forewarned!) ***Make sure you use thick enough wiring!*** I replaced my jumper cables with 18AWG wires, as well as reduced freely floating ground daisy chain clumps, and my build seems to hold up to sustained solenoid use now.
 
 ## TODO (can and will implement, just not now):
-- Implement expanded preferences saving/loading to/from EEPROM/flash. Should allow setting variables at runtime through the eventual GUI/serial and overriding pins layout with customs.
 - Should implement support for rumble as an alternative force-feedback system (`RUMBLE_FF`); able to do so now, just have to do it.
 - Code is still kind of a mess, so I should clean things up at some point maybe kinda.
 

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -3254,7 +3254,7 @@ void SerialProcessing()                                         // Reading the i
                 } else {
                     Serial.println("SERIALREAD: Internal setting command detected, but no valid option found!");
                     Serial.println("Internally recognized commands are:");
-                    Serial.println("A(nalog) / T(est) / R(emap)1/2/3/4 / P(ause) / C(alibrate)[1/2/3/4] / S(ave) / [(profile) 1/2/3/4]");
+                    Serial.println("A(nalog) / C(alibrate)[1/2/3/4] / I(nterval Autofire)2/3/4 / P(ause) / R(emap)1/2/3/4 / S(ave) / T(est) / [(profile) 1/2/3/4]");
                 }
                 break;
           }

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -2948,6 +2948,96 @@ void SerialProcessing()                                         // Reading the i
                         break;
                     }
                 #endif // USE_TINYUSB
+                } else { // "default" - print out help
+                    Serial.println("Xm - Update mappings.");
+                    Serial.println("Usage: Xm.x.y.z");
+                    Serial.println("");
+                    #ifdef USE_TINYUSB
+                    Serial.println("`x` - 0 = Booleans, 1 = Pins, 2 = Extended Settings, 3 = TinyUSB");
+                    #else
+                    Serial.println("`x` - 0 = Booleans, 1 = Pins, 2 = Extended Settings");
+                    #endif
+                    Serial.println("");
+                    Serial.print("`y` Booleans | ");
+                    #ifdef USES_RUMBLE
+                    Serial.print("0 = Rumble On/Off, ");
+                    #endif
+                    #ifdef USES_SOLENOID
+                    Serial.print("1 = Solenoid On/Off, ");
+                    #endif
+                    Serial.print("2 = Autofire On/Off, 3 = Simple Pause Menu, 4 = Hold to Pause Enabled, ");
+                    #ifdef FOURPIN_LED
+                    Serial.print("5 = 4-Pin Common Anode, ");
+                    #endif
+                    Serial.println("6 = Low Buttons Mode");
+                    Serial.println("`z` Booleans | 0 = Off, 1 = On");
+                    Serial.println("");
+                    Serial.print("`y` Pins Mapping | ");
+                    Serial.print("[0]Custom Pins Enabled (Boolean), [1]Trigger, [2]A, [3]B, [4]C, [5]Start, [6]Select, [7]Up, [8]Down, [9]Left, [10]Right, [11]Pedal, [12]Home, [13]Pump Action, ");
+                    #ifdef USES_RUMBLE
+                    Serial.print("[14]Rumble Pin, ");
+                    #else
+                    Serial.print("[.]Rumble Pin (Unused), ");
+                    #endif // USES_RUMBLE
+                    #ifdef USES_SOLENOID
+                    Serial.print("[15]Solenoid Pin, ");
+                    #ifdef USES_TEMP
+                    Serial.print("[16]Temperature Sensor Pin, ");
+                    #else
+                    Serial.print("[.]Temperature Sensor (Unused), ");
+                    #endif // USES_TEMP
+                    #else
+                    Serial.print("[.]Solenoid Pin (Unused), [.]Temperature Sensor (Unused), ");
+                    #endif // USES_SOLENOID
+                    #ifdef USES_SWITCHES
+                    #ifdef USES_RUMBLE
+                    Serial.print("[17]Rumble Switch, ");
+                    #else
+                    Serial.print("[.]Rumble Switch (Unused), ");
+                    #endif // USES_RUMBLE
+                    #ifdef USES_SOLENOID
+                    Serial.print("[18]Solenoid Switch, ");
+                    #else
+                    Serial.print("[.]Solenoid Switch (Unused), ");
+                    #endif // USES_SOLENOID
+                    Serial.print("[19]Autofire Switch, ");
+                    #else
+                    Serial.print("[.]Rumble Switch (Unused), [.]Solenoid Switch (Unused), [.]Autofire Switch (Unused), ");
+                    #endif // USES_SWITCHES
+                    #ifdef FOURPIN_LED
+                    Serial.print("[20]LED Pin R, [21]LED Pin G, [22]LED Pin B, ");
+                    #else
+                    Serial.print("[.]LED Pin R (Unused), [.]LED Pin G (Unused), [.]LED Pin B (Unused), ");
+                    #endif // FOURPIN_LED
+                    #ifdef CUSTOM_NEOPIXEL
+                    Serial.print("[23]External NeoPixel Output Pin, ");
+                    #else
+                    Serial.print("[.]External NeoPixel Pin (Unused), ");
+                    #endif // CUSTOM_NEOPIXEL
+                    #ifdef USES_ANALOG
+                    Serial.println("[24]Analog Pin X, [25]Analog Pin Y, ");
+                    #else
+                    Serial.println("[.]Analog Pin X (Unused), [.]Analog Pin Y (Unused).");
+                    #endif // USES_ANALOG
+                    Serial.println("`z` Pins Mapping | 0 = Disabled, 1 = Enabled (Custom Pins Setting only) / 0-40 = Set to GPIO Pin #, -1 = Disabled (Any pin)");
+                    Serial.println("");
+                    Serial.print("`y` Extended Settings | ");
+                    #ifdef USES_RUMBLE
+                    Serial.print("[0] Rumble Intensity (0-255), [1] Rumble Event Length (0-9999, in ms), ");
+                    #endif // USES_RUMBLE
+                    #ifdef USES_SOLENOID
+                    Serial.print("[2] Solenoid Normal Interval (0-9999, in ms), [3] Solenoid Fast Interval (0-9999, in ms), [4] Solenoid Hold Length (0-9999, in ms), ");
+                    #endif // USES_SOLENOID
+                    #ifdef CUSTOM_NEOPIXEL
+                    Serial.print("[5] NeoPixel Strand Length (1-255, in LEDs count), ");
+                    #endif // CUSTOM_NEOPIXEL
+                    Serial.println("[6] Autofire Wait Factor (2-4), [7] Hold-to-Pause Length (0-9999, in ms).");
+                    Serial.println("`z` Extended Settings | Any positive int");
+                    #ifdef USE_TINYUSB
+                    Serial.println("");
+                    Serial.println("`y` TinyUSB Identifier | 0 = Product ID, 1 = Product Name");
+                    Serial.println("`z` TinyUSB Identifier | Any decimal int (ID, converts to Hex), Up to 15 ASCII Characters (Name).");
+                    #endif // USE_TINYUSB
                 }
                 break;
               }

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -4044,6 +4044,19 @@ void ExtPreferences(bool isLoad)
     uint8_t tempBools = 0b00000000;
     uint8_t *dataBools = &tempBools;
 
+    #ifdef USES_RUMBLE
+        bitWrite(tempBools, 0, rumbleActive);
+    #endif // USES_RUMBLE
+    #ifdef USES_SOLENOID
+        bitWrite(tempBools, 1, solenoidActive);
+    #endif // USES_SOLENOID
+    bitWrite(tempBools, 2, autofireActive);
+    bitWrite(tempBools, 3, simpleMenu);
+    bitWrite(tempBools, 4, holdToPause);
+    #ifdef FOURPIN_LED
+        bitWrite(tempBools, 5, commonAnode);
+    #endif // FOURPIN_LED
+
     // Temp pin mappings
     int8_t tempMappings[] = {
       customPinsInUse,            // custom pin enabled - disabled by default

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -424,13 +424,11 @@ uint32_t OffscreenButtonToggleBtnMask = BtnMask_Reload | BtnMask_A;
 // button combination to toggle offscreen button mode in software:
 uint32_t AutofireSpeedToggleBtnMask = BtnMask_Reload | BtnMask_B;
 
-#ifndef USES_SWITCHES
 // button combination to toggle rumble in software:
 uint32_t RumbleToggleBtnMask = BtnMask_Left;
 
 // button combination to toggle solenoid in software:
 uint32_t SolenoidToggleBtnMask = BtnMask_Right;
-#endif
 
 // colour when no IR points are seen
 uint32_t IRSeen0Color = WikiColor::Amber;
@@ -1510,16 +1508,14 @@ void loop()
                 OffscreenToggle();
             } else if(buttons.pressedReleased == AutofireSpeedToggleBtnMask) {
                 AutofireSpeedToggle(0);
-            #ifndef USES_SWITCHES // Builds without hardware switches needs software toggles
-                #ifdef USES_RUMBLE
-                    } else if(buttons.pressedReleased == RumbleToggleBtnMask) {
-                        RumbleToggle();
-                #endif // USES_RUMBLE
-                #ifdef USES_SOLENOID
-                    } else if(buttons.pressedReleased == SolenoidToggleBtnMask) {
-                        SolenoidToggle();
-                #endif // USES_SOLENOID
-            #endif // ifndef USES_TOGGLES
+            #ifdef USES_RUMBLE
+                } else if(buttons.pressedReleased == RumbleToggleBtnMask && rumbleSwitch >= 0) {
+                    RumbleToggle();
+            #endif // USES_RUMBLE
+            #ifdef USES_SOLENOID
+                } else if(buttons.pressedReleased == SolenoidToggleBtnMask && solenoidSwitch >= 0) {
+                    SolenoidToggle();
+            #endif // USES_SOLENOID
             } else {
                 SelectCalProfileFromBtnMask(buttons.pressedReleased);
             }

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -2609,7 +2609,13 @@ void SerialProcessing()                                         // Reading the i
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         rumbleActive = serialInput - '0';
-                        Serial.println("Toggled Rumble setting.");
+                        rumbleActive = constrain(rumbleActive, 0, 1);
+                        Serial.print("Toggled Rumble setting ");
+                        if(rumbleActive) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       #endif
                       #ifdef USES_SOLENOID
@@ -2617,45 +2623,78 @@ void SerialProcessing()                                         // Reading the i
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         solenoidActive = serialInput - '0';
-                        Serial.println("Toggled Solenoid setting.");
+                        solenoidActive = constrain(solenoidActive, 0, 1);
+                        Serial.print("Toggled Solenoid setting ");
+                        if(solenoidActive) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       #endif
                       case '2':
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         autofireActive = serialInput - '0';
-                        Serial.println("Toggled Autofire setting.");
+                        autofireActive = constrain(autofireActive, 0, 1);
+                        Serial.print("Toggled Autofire setting ");
+                        if(autofireActive) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       case '3':
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         simpleMenu = serialInput - '0';
-                        Serial.println("Toggled Simple Pause Menu setting.");
+                        simpleMenu = constrain(simpleMenu, 0, 1);
+                        Serial.print("Toggled Simple Pause Menu setting ");
+                        if(simpleMenu) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       case '4':
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         holdToPause = serialInput - '0';
-                        Serial.println("Toggled Hold to Pause setting.");
+                        holdToPause = constrain(holdToPause, 0, 1);
+                        Serial.print("Toggled Hold to Pause setting ");
+                        if(holdToPause) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       #ifdef FOURPIN_LED
                       case '5':
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         commonAnode = serialInput - '0';
-                        Serial.println("Toggled Common Anode setting.");
+                        commonAnode = constrain(commonAnode, 0, 1);
+                        Serial.print("Toggled Common Anode setting ");
+                        if(commonAnode) {
+                          Serial.println("ON.");
+                        } else {
+                          Serial.println("OFF.");
+                        }
                         break;
                       #endif
                       case '6':
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         lowButtonMode = serialInput - '0';
+                        lowButtonMode = constrain(lowButtonMode, 0, 1);
+                        Serial.print("Toggled Low Button Mode setting ");
                         if(lowButtonMode) {
                             UpdateBindings(true);
+                            Serial.println("ON.");
                         } else {
                             UpdateBindings(false);
+                            Serial.println("OFF.");
                         }
-                        Serial.println("Toggled Low Button Mode setting.");
                         break;
                     }
                 // Pins
@@ -2667,6 +2706,7 @@ void SerialProcessing()                                         // Reading the i
                         serialInput = Serial.read(); // nomf
                         serialInput = Serial.read();
                         customPinsInUse = serialInput - '0';
+                        customPinsInUse = constrain(customPinsInUse, 0, 1);
                         if(customPinsInUse) {
                             Serial.print("Toggled custom pin setting on; ");
                         } else {
@@ -2677,78 +2717,91 @@ void SerialProcessing()                                         // Reading the i
                       case 1:
                         serialInput = Serial.read(); // nomf
                         btnTrigger = Serial.parseInt();
+                        btnTrigger = constrain(btnTrigger, -1, 40);
                         Serial.print("Set trigger button pin to: ");
                         Serial.println(btnTrigger);
                         break;
                       case 2:
                         serialInput = Serial.read(); // nomf
                         btnGunA = Serial.parseInt();
+                        btnGunA = constrain(btnGunA, -1, 40);
                         Serial.print("Set A button pin to: ");
                         Serial.println(btnGunA);
                         break;
                       case 3:
                         serialInput = Serial.read(); // nomf
                         btnGunB = Serial.parseInt();
+                        btnGunB = constrain(btnGunB, -1, 40);
                         Serial.print("Set B button pin to: ");
                         Serial.println(btnGunB);
                         break;
                       case 4:
                         serialInput = Serial.read(); // nomf
                         btnGunC = Serial.parseInt();
+                        btnGunC = constrain(btnGunC, -1, 40);
                         Serial.print("Set C button pin to: ");
                         Serial.println(btnGunC);
                         break;
                       case 5:
                         serialInput = Serial.read(); // nomf
                         btnStart = Serial.parseInt();
+                        btnStart = constrain(btnStart, -1, 40);
                         Serial.print("Set Start button pin to: ");
                         Serial.println(btnStart);
                         break;
                       case 6:
                         serialInput = Serial.read(); // nomf
                         btnSelect = Serial.parseInt();
+                        btnSelect = constrain(btnSelect, -1, 40);
                         Serial.print("Set Select button pin to: ");
                         Serial.println(btnSelect);
                         break;
                       case 7:
                         serialInput = Serial.read(); // nomf
                         btnGunUp = Serial.parseInt();
+                        btnGunUp = constrain(btnGunUp, -1, 40);
                         Serial.print("Set D-Pad Up button pin to: ");
                         Serial.println(btnGunUp);
                         break;
                       case 8:
                         serialInput = Serial.read(); // nomf
                         btnGunDown = Serial.parseInt();
+                        btnGunDown = constrain(btnGunDown, -1, 40);
                         Serial.print("Set D-Pad Down button pin to: ");
                         Serial.println(btnGunDown);
                         break;
                       case 9:
                         serialInput = Serial.read(); // nomf
                         btnGunLeft = Serial.parseInt();
+                        btnGunLeft = constrain(btnGunLeft, -1, 40);
                         Serial.print("Set D-Pad Left button pin to: ");
                         Serial.println(btnGunLeft);
                         break;
                       case 10:
                         serialInput = Serial.read(); // nomf
                         btnGunRight = Serial.parseInt();
+                        btnGunRight = constrain(btnGunRight, -1, 40);
                         Serial.print("Set D-Pad Right button pin to: ");
                         Serial.println(btnGunRight);
                         break;
                       case 11:
                         serialInput = Serial.read(); // nomf
                         btnPedal = Serial.parseInt();
+                        btnPedal = constrain(btnPedal, -1, 40);
                         Serial.print("Set External Pedal button pin to: ");
                         Serial.println(btnPedal);
                         break;
                       case 12:
                         serialInput = Serial.read(); // nomf
                         btnHome = Serial.parseInt();
+                        btnHome = constrain(btnHome, -1, 40);
                         Serial.print("Set Home button pin to: ");
                         Serial.println(btnHome);
                         break;
                       case 13:
                         serialInput = Serial.read(); // nomf
                         btnPump = Serial.parseInt();
+                        btnPump = constrain(btnPump, -1, 40);
                         Serial.print("Set Pump Action button pin to: ");
                         Serial.println(btnPump);
                         break;
@@ -2756,6 +2809,7 @@ void SerialProcessing()                                         // Reading the i
                       case 14:
                         serialInput = Serial.read(); // nomf
                         rumblePin = Serial.parseInt();
+                        rumblePin = constrain(rumblePin, -1, 40);
                         Serial.print("Set Rumble signal pin to: ");
                         Serial.println(rumblePin);
                         break;
@@ -2764,6 +2818,7 @@ void SerialProcessing()                                         // Reading the i
                       case 15:
                         serialInput = Serial.read(); // nomf
                         solenoidPin = Serial.parseInt();
+                        solenoidPin = constrain(solenoidPin, -1, 40);
                         Serial.print("Set Solenoid signal pin to: ");
                         Serial.println(solenoidPin);
                         break;
@@ -2771,6 +2826,7 @@ void SerialProcessing()                                         // Reading the i
                       case 16:
                         serialInput = Serial.read(); // nomf
                         tempPin = Serial.parseInt();
+                        tempPin = constrain(tempPin, -1, 40);
                         Serial.print("Set Temperature Sensor pin to: ");
                         Serial.println(tempPin);
                         break;
@@ -2781,6 +2837,7 @@ void SerialProcessing()                                         // Reading the i
                       case 17:
                         serialInput = Serial.read(); // nomf
                         rumbleSwitch = Serial.parseInt();
+                        rumbleSwitch = constrain(rumbleSwitch, -1, 40);
                         Serial.print("Set Rumble Switch pin to: ");
                         Serial.println(rumbleSwitch);
                         break;
@@ -2789,6 +2846,7 @@ void SerialProcessing()                                         // Reading the i
                       case 18:
                         serialInput = Serial.read(); // nomf
                         solenoidSwitch = Serial.parseInt();
+                        solenoidSwitch = constrain(solenoidSwitch, -1, 40);
                         Serial.print("Set Solenoid Switch pin to: ");
                         Serial.println(solenoidSwitch);
                         break;
@@ -2796,6 +2854,7 @@ void SerialProcessing()                                         // Reading the i
                       case 19:
                         serialInput = Serial.read(); // nomf
                         autofireSwitch = Serial.parseInt();
+                        autofireSwitch = constrain(autofireSwitch, -1, 40);
                         Serial.print("Set Autofire Switch pin to: ");
                         Serial.println(autofireSwitch);
                         break;
@@ -2804,18 +2863,21 @@ void SerialProcessing()                                         // Reading the i
                       case 20:
                         serialInput = Serial.read(); // nomf
                         PinR = Serial.parseInt();
+                        PinR = constrain(PinR, -1, 40);
                         Serial.print("Set Fourpin LED R pin to: ");
                         Serial.println(PinR);
                         break;
                       case 21:
                         serialInput = Serial.read(); // nomf
                         PinG = Serial.parseInt();
+                        PinG = constrain(PinG, -1, 40);
                         Serial.print("Set Fourpin LED G pin to: ");
                         Serial.println(PinG);
                         break;
                       case 22:
                         serialInput = Serial.read(); // nomf
                         PinB = Serial.parseInt();
+                        PinB = constrain(PinB, -1, 40);
                         Serial.print("Set Fourpin LED B pin to: ");
                         Serial.println(PinB);
                         break;
@@ -2824,6 +2886,7 @@ void SerialProcessing()                                         // Reading the i
                       case 23:
                         serialInput = Serial.read(); // nomf
                         customLEDpin = Serial.parseInt();
+                        customLEDpin = constrain(customLEDpin, -1, 40);
                         Serial.print("Set NeoPixel pin to: ");
                         Serial.println(customLEDpin);
                         break;
@@ -2832,12 +2895,14 @@ void SerialProcessing()                                         // Reading the i
                       case 24:
                         serialInput = Serial.read(); // nomf
                         analogPinX = Serial.parseInt();
+                        analogPinX = constrain(analogPinX, -1, 40);
                         Serial.print("Set Analog X pin to: ");
                         Serial.println(analogPinX);
                         break;
                       case 25:
                         serialInput = Serial.read(); // nomf
                         analogPinY = Serial.parseInt();
+                        analogPinY = constrain(analogPinY, -1, 40);
                         Serial.print("Set Analog Y pin to: ");
                         Serial.println(analogPinY);
                         break;

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -824,11 +824,15 @@ void setup() {
     #ifdef USES_RUMBLE
         if(rumblePin >= 0) {
             pinMode(rumblePin, OUTPUT);
+        } else {
+            rumbleActive = false;
         }
     #endif // USES_RUMBLE
     #ifdef USES_SOLENOID
         if(solenoidPin >= 0) {
             pinMode(solenoidPin, OUTPUT);
+        } else {
+            solenoidActive = false;
         }
     #endif // USES_SOLENOID
     #ifdef USES_SWITCHES
@@ -1193,7 +1197,7 @@ void loop1()
         #ifdef USES_ANALOG
             if(analogIsValid) {
                 // We tie analog stick updates to the IR camera timer, so as to not overload USB bandwidth.
-                // For some reason, tying it to irPosUpdateTick explicitly prevents mouse dropout.
+                // For some reason, tying it to irPosUpdateTick exclusively prevents mouse dropout.
                 if(!analogStickPolled && irPosUpdateTick) {
                     AnalogStickPoll();
                     analogStickPolled = true;

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -4181,6 +4181,7 @@ void ExtPreferences(bool isLoad)
         #ifdef FOURPIN_LED
             commonAnode = bitRead(tempBools, 5);
         #endif // FOURPIN_LED
+        lowButtonMode = bitRead(tempBools, 6);
 
         // Set pins, if allowed.
         customPinsInUse = tempMappings[0];

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -180,7 +180,7 @@ bool lowButtonMode = false;                       // Flag that determines if but
     #define LED_ENABLE
     #include <Adafruit_NeoPixel.h>
     int8_t customLEDpin = -1;                     // Pin number for the custom NeoPixel (strip) being used.
-    uint8_t customLEDcount = 1;                   // Amount of pixels; if not using a strip, just set to 1.
+    uint16_t customLEDcount = 1;                   // Amount of pixels; if not using a strip, just set to 1.
 #endif // CUSTOM_NEOPIXEL
 
   // Adjustable aspects:
@@ -828,8 +828,8 @@ void setup() {
     startIrCamTimer(IRCamUpdateRate);
 
     // First boot sanity checks.
-    // Check if the initial profiles are blanked.
-    if(profileData[selectedProfile].xScale == 0) {
+    // Check if the initial profiles are blanked (zero center = init)
+    if(profileData[selectedProfile].xCenter == 0 || profileData[selectedProfile].yCenter == 0) {
         // SHIT, it's a first boot! Prompt to start calibration.
         Serial.println("Preferences data is empty!");
         SetMode(GunMode_CalCenter);

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -90,80 +90,73 @@
 
   // Leave this uncommented if your build uses hardware switches, or comment out to disable all references to hw switch functionality.
 #define USES_SWITCHES
-#ifdef USES_SWITCHES // Here's where they should be defined!
-    int8_t autofireSwitch = 18;                   // What's the pin number of the autofire switch? Digital.
-#endif // USES_SWITCHES
 
   // Leave this uncommented if your build uses a rumble motor; comment out to disable any references to rumble functionality.
 #define USES_RUMBLE
-#ifdef USES_RUMBLE
-    bool rumbleActive = true;                         // Are we allowed to do rumble? Default to off.
-    #ifdef USES_SWITCHES
-        int8_t rumbleSwitch = 19;                 // What's the pin number of the rumble switch? Digital.
-    #endif // USES_SWITCHES
-
-    // If you'd rather not use a solenoid for force-feedback effects, this will change all on-screen force feedback events to use the motor instead.
-    // TODO: actually finish this.
-    //#define RUMBLE_FF
-    #if defined(RUMBLE_FF) && defined(USES_SOLENOID)
-        #error Rumble Force-feedback is incompatible with Solenoids! Use either one or the other.
-    #endif // RUMBLE_FF && USES_SOLENOID
-#endif // USES_RUMBLE
 
   // Leave this uncommented if your build uses a solenoid, or comment out to disable any references to solenoid functionality.
 #define USES_SOLENOID
 #ifdef USES_SOLENOID
-    bool solenoidActive = false;                      // Are we allowed to use a solenoid? Default to off.
-    #ifdef USES_SWITCHES // If your build uses hardware switches,
-        int8_t solenoidSwitch = 20;               // What's the pin number of the solenoid switch? Digital.
-    #endif // USES_SWITCHES
-    
-  // Uncomment if your build uses a TMP36 temperature sensor for a solenoid, or comment out if your solenoid doesn't need babysitting.
+    // Uncomment if your build uses a TMP36 temperature sensor for a solenoid, or comment out if your solenoid doesn't need babysitting.
     //#define USES_TEMP
-    #ifdef USES_TEMP    
-        int8_t tempPin = A0;                      // What's the pin number of the temp sensor? Needs to be analog.
-        uint16_t tempNormal = 50;                 // Solenoid: Anything below this value is "normal" operating temperature for the solenoid, in Celsius.
-        uint16_t tempWarning = 60;                // Solenoid: Above normal temps, this is the value up to where we throttle solenoid activation, in Celsius.
-    #endif // USES_TEMP                               // **Anything above ^this^ is considered too dangerous, will disallow any further engagement.
 #endif // USES_SOLENOID
 
+  // Leave this uncommented if your build uses an analog stick.
+#define USES_ANALOG
+
+  // Leave this uncommented if your build uses a four pin RGB LED.
+#define FOURPIN_LED
+
+  // Leave this uncommented if your build uses an external NeoPixel.
+#define CUSTOM_NEOPIXEL
 
   // Which software extras should be activated? Set here if your build doesn't use toggle switches.
 bool autofireActive = false;                          // Is solenoid firing in autofire (rapid) mode? false = default single shot, true = autofire
 bool offscreenButton = false;                         // Does shooting offscreen also send a button input (for buggy games that don't recognize off-screen shots)? Default to off.
 bool burstFireActive = false;                         // Is the solenoid firing in burst fire mode? false = default, true = 3-shot burst firing mode
 
+#ifdef ARDUINO_ADAFRUIT_ITSYBITSY_RP2040 // For the Adafruit ItsyBitsy RP2040
+#ifdef USES_SWITCHES
+    int8_t autofireSwitch = 18;                   // What's the pin number of the autofire switch? Digital.
+    #ifdef USES_RUMBLE
+        int8_t rumbleSwitch = 19;                 // What's the pin number of the rumble switch? Digital.
+    #endif // USES_RUMBLE
+    #ifdef USES_SOLENOID
+        int8_t solenoidSwitch = 20;               // What's the pin number of the solenoid switch? Digital.
+    #endif // USES_SOLENOID
+#endif // USES_SWITCHES
 
-  // Pins setup - where do things be plugged into like? Uses GPIO codes ONLY! See also: https://learn.adafruit.com/adafruit-itsybitsy-rp2040/pinouts
-int8_t rumblePin = 24;                            // What's the pin number of the rumble output? Needs to be digital.
-int8_t solenoidPin = 25;                          // What's the pin number of the solenoid output? Needs to be digital.
-int8_t btnTrigger = 6;                            // Programmer's note: made this just to simplify the trigger pull detection, guh.
-int8_t btnGunA = 7;                               // <-- GCon 1-spec
-int8_t btnGunB = 8;                               // <-- GCon 1-spec
-int8_t btnGunC = 9;                               // Everything below are for GCon 2-spec only 
-int8_t btnStart = 10;
-int8_t btnSelect = 11;
-int8_t btnGunUp = 1;
-int8_t btnGunDown = 0;
-int8_t btnGunLeft = 4;
-int8_t btnGunRight = 5;
-int8_t btnPedal = 12;                             // If you're using a physical Time Crisis-style pedal, this is for that.
-int8_t btnPump = -1;
-int8_t btnHome = -1;
+#ifdef USES_RUMBLE
+    // If you'd rather not use a solenoid for force-feedback effects, this will change all on-screen force feedback events to use the motor instead.
+    // TODO: actually finish this.
+    //#define RUMBLE_FF
+    #if defined(RUMBLE_FF) && defined(USES_SOLENOID)
+        #error Rumble Force-feedback is incompatible with Solenoids! Use either one or the other.
+    #endif // RUMBLE_FF && USES_SOLENOID
+    bool rumbleActive = true;                         // Are we allowed to do rumble? Default to off.
+    uint16_t rumbleIntensity = 170;               // The strength of the rumble motor, 0=off to 255=maxPower.
+    uint16_t rumbleInterval = 150;          // How long to wait for the whole rumble command, in ms.
+#endif // USES_RUMBLE
 
-bool lowButtonMode = false;                       // Flag that determines if buttons A/B will be Start/Select when pointing offscreen; for Sega Stunner and GunCon 1-spec guns mainly.
+#ifdef USES_SOLENOID
+    bool solenoidActive = true;                      // Are we allowed to use a solenoid? Default to off.
+    #ifdef USES_TEMP    
+        int8_t tempPin = A2;                      // What's the pin number of the temp sensor? Needs to be analog.
+        uint16_t tempNormal = 50;                   // Solenoid: Anything below this value is "normal" operating temperature for the solenoid, in Celsius.
+        uint16_t tempWarning = 60;                  // Solenoid: Above normal temps, this is the value up to where we throttle solenoid activation, in Celsius.
+    #endif // USES_TEMP                               // **Anything above ^this^ is considered too dangerous, will disallow any further engagement.
+    uint16_t solenoidNormalInterval = 45;   // Interval for solenoid activation, in ms.
+    uint16_t solenoidFastInterval = 30;     // Interval for faster solenoid activation, in ms.
+    uint16_t solenoidLongInterval = 500;    // for single shot, how long to wait until we start spamming the solenoid? In ms.
+#endif // USES_SOLENOID
 
-  // If your build uses an analog stick, unset and define the stick's pins here!
   // Remember: ANALOG PINS ONLY!
-//#define USES_ANALOG
 #ifdef USES_ANALOG
-    int8_t analogPinX = -1;
-    int8_t analogPinY = -1;
+    int8_t analogPinX = A0;
+    int8_t analogPinY = A1;
 #endif // USES_ANALOG
 
-  // If you're using a regular 4-pin RGB LED, unset and define the R/G/B color pins here!
   // Remember: PWM PINS ONLY!
-//#define FOURPIN_LED
 #ifdef FOURPIN_LED
     #define LED_ENABLE
     int8_t PinR = -1;
@@ -173,27 +166,111 @@ bool lowButtonMode = false;                       // Flag that determines if but
     bool commonAnode = true;
 #endif // FOURPIN_LED
 
-  // If you're using a custom external NeoPixel unit, unset and define the data pin location here!
   // Any digital pin is fine for NeoPixels. Currently we only use the first "pixel".
-//#define CUSTOM_NEOPIXEL
 #ifdef CUSTOM_NEOPIXEL
     #define LED_ENABLE
     #include <Adafruit_NeoPixel.h>
-    int8_t customLEDpin = -1;                     // Pin number for the custom NeoPixel (strip) being used.
+    int8_t customLEDpin = -1;                      // Pin number for the custom NeoPixel (strip) being used.
     uint16_t customLEDcount = 1;                   // Amount of pixels; if not using a strip, just set to 1.
 #endif // CUSTOM_NEOPIXEL
 
-  // Adjustable aspects:
-uint16_t autofireWaitFactor = 3;                  // This is the default time to wait between rapid fire pulses (from 2-4)
+  // Pins setup - where do things be plugged into like? Uses GPIO codes ONLY! See also: https://learn.adafruit.com/adafruit-itsybitsy-rp2040/pinouts
+int8_t rumblePin = 24;                            // What's the pin number of the rumble output? Needs to be digital.
+int8_t solenoidPin = 25;                          // What's the pin number of the solenoid output? Needs to be digital.
+int8_t btnTrigger = 6;                           // Programmer's note: made this just to simplify the trigger pull detection, guh.
+int8_t btnGunA = 7;                              // <-- GCon 1-spec
+int8_t btnGunB = 8;                              // <-- GCon 1-spec
+int8_t btnGunC = 9;                              // Everything below are for GCon 2-spec only 
+int8_t btnStart = 10;
+int8_t btnSelect = 11;
+int8_t btnGunUp = 1;
+int8_t btnGunDown = 0;
+int8_t btnGunLeft = 4;
+int8_t btnGunRight = 5;
+int8_t btnPedal = 12;
+int8_t btnPump = -1;
+int8_t btnHome = -1;
+
+#else // For the Raspberry Pi Pico
+
+#ifdef USES_SWITCHES
+    int8_t autofireSwitch = -1;                   // What's the pin number of the autofire switch? Digital.
+    #ifdef USES_SOLENOID
+        int8_t solenoidSwitch = -1;               // What's the pin number of the solenoid switch? Digital.
+    #endif // USES_SOLENOID
+    #ifdef USES_RUMBLE
+        int8_t rumbleSwitch = -1;                 // What's the pin number of the rumble switch? Digital.
+    #endif // USES_RUMBLE
+#endif // USES_SWITCHES
+
 #ifdef USES_RUMBLE
-    uint16_t rumbleIntensity = 255;             // The strength of the rumble motor, 0=off to 255=maxPower.
-    uint16_t rumbleInterval = 110;              // How long to wait for the whole rumble command, in ms.
+    // If you'd rather not use a solenoid for force-feedback effects, this will change all on-screen force feedback events to use the motor instead.
+    // TODO: actually finish this.
+    //#define RUMBLE_FF
+    #if defined(RUMBLE_FF) && defined(USES_SOLENOID)
+        #error Rumble Force-feedback is incompatible with Solenoids! Use either one or the other.
+    #endif // RUMBLE_FF && USES_SOLENOID
+    bool rumbleActive = true;                         // Are we allowed to do rumble? Default to off.
+    uint16_t rumbleIntensity = 170;               // The strength of the rumble motor, 0=off to 255=maxPower.
+    uint16_t rumbleInterval = 150;          // How long to wait for the whole rumble command, in ms.
 #endif // USES_RUMBLE
+
 #ifdef USES_SOLENOID
-    uint16_t solenoidNormalInterval = 45;       // Interval for solenoid activation, in ms.
-    uint16_t solenoidFastInterval = 30;         // Interval for faster solenoid activation, in ms.
-    uint16_t solenoidLongInterval = 500;        // for single shot, how long to wait until we start spamming the solenoid? In ms.
+    bool solenoidActive = true;                      // Are we allowed to use a solenoid? Default to off.
+    #ifdef USES_TEMP    
+        int8_t tempPin = A2;                      // What's the pin number of the temp sensor? Needs to be analog.
+        uint16_t tempNormal = 50;                   // Solenoid: Anything below this value is "normal" operating temperature for the solenoid, in Celsius.
+        uint16_t tempWarning = 60;                  // Solenoid: Above normal temps, this is the value up to where we throttle solenoid activation, in Celsius.
+    #endif // USES_TEMP                               // **Anything above ^this^ is considered too dangerous, will disallow any further engagement.
+    uint16_t solenoidNormalInterval = 45;   // Interval for solenoid activation, in ms.
+    uint16_t solenoidFastInterval = 30;     // Interval for faster solenoid activation, in ms.
+    uint16_t solenoidLongInterval = 500;    // for single shot, how long to wait until we start spamming the solenoid? In ms.
 #endif // USES_SOLENOID
+
+  // Remember: ANALOG PINS ONLY!
+#ifdef USES_ANALOG
+    int8_t analogPinX = A0;
+    int8_t analogPinY = A1;
+#endif // USES_ANALOG
+
+  // Remember: PWM PINS ONLY!
+#ifdef FOURPIN_LED
+    #define LED_ENABLE
+    int8_t PinR = 10;
+    int8_t PinG = 11;
+    int8_t PinB = 12;
+    // Set if your LED is Common Anode (+, connects to 5V) rather than Common Cathode (-, connects to GND)
+    bool commonAnode = true;
+#endif // FOURPIN_LED
+
+  // Any digital pin is fine for NeoPixels. Currently we only use the first "pixel".
+#ifdef CUSTOM_NEOPIXEL
+    #define LED_ENABLE
+    #include <Adafruit_NeoPixel.h>
+    int8_t customLEDpin = -1;                      // Pin number for the custom NeoPixel (strip) being used.
+    uint16_t customLEDcount = 1;                   // Amount of pixels; if not using a strip, just set to 1.
+#endif // CUSTOM_NEOPIXEL
+
+int8_t rumblePin = 17;                            // What's the pin number of the rumble output? Needs to be digital.
+int8_t solenoidPin = 16;                          // What's the pin number of the solenoid output? Needs to be digital.
+int8_t btnTrigger = 15;                           // Programmer's note: made this just to simplify the trigger pull detection, guh.
+int8_t btnGunA = 0;                              // <-- GCon 1-spec
+int8_t btnGunB = 1;                              // <-- GCon 1-spec
+int8_t btnGunC = 2;                              // Everything below are for GCon 2-spec only 
+int8_t btnStart = 3;
+int8_t btnSelect = 4;
+int8_t btnGunUp = 6;
+int8_t btnGunDown = 7;
+int8_t btnGunLeft = 8;
+int8_t btnGunRight = 9;
+int8_t btnPedal = 14;
+int8_t btnPump = 13;
+int8_t btnHome = 5;
+
+#endif // ARDUINO_ADAFRUIT_ITSYBITSY_RP2040
+
+bool lowButtonMode = false;                           // Flag that determines if buttons A/B will be Start/Select when pointing offscreen; for Sega Stunner and GunCon 1-spec guns mainly.
+uint16_t autofireWaitFactor = 3;                      // This is the default time to wait between rapid fire pulses (from 2-4)
 
 // Menu options:
 bool simpleMenu = false;                              // Flag that determines if Pause Mode will be a simple scrolling menu; else, relies on hotkeys.
@@ -522,7 +599,7 @@ bool customPinsInUse = false;                        // For if custom pins defin
 
 unsigned int lastSeen = 0;
 
-bool justBooted = true;                              // For ops we need to do on initial boot (just joystick centering atm)
+bool justBooted = true;                              // For ops we need to do on initial boot (custom pins, joystick centering)
 
 #ifdef EXTRA_POS_GLITCH_FILTER00
 int badFinalTick = 0;
@@ -797,9 +874,8 @@ void setup() {
     Wire1.setSDA(2);
     Wire1.setSCL(3);
 #endif
-// Wire (0) should be defaulting to and using GPIO 4 & 5, but in case you need it:
-// Wire.setSDA(4);
-// Wire.setSCL(5);
+    Wire.setSDA(20);
+    Wire.setSCL(21);
 
     // initialize buttons
     buttons.Begin();
@@ -2432,13 +2508,15 @@ void SerialProcessing()                                         // Reading the i
                 break;
               // Toggle Pause/Run Mode
               case 'P':
-                if(gunMode != GunMode_Run) {
-                    Serial.println("Exiting back to normal run mode...");
-                    SetMode(GunMode_Run);
-                } else {
-                    Serial.println("Entering pause mode...");
-                    buttons.ReportDisable();
-                    SetMode(GunMode_Pause);
+                if(!justBooted) {
+                    if(gunMode != GunMode_Run) {
+                        Serial.println("Exiting back to normal run mode...");
+                        SetMode(GunMode_Run);
+                    } else {
+                        Serial.println("Entering pause mode...");
+                        buttons.ReportDisable();
+                        SetMode(GunMode_Pause);
+                    }
                 }
                 break;
               // Enter Calibration mode (optional: switch to cal profile if detected)

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -4044,18 +4044,20 @@ void ExtPreferences(bool isLoad)
     uint8_t tempBools = 0b00000000;
     uint8_t *dataBools = &tempBools;
 
-    #ifdef USES_RUMBLE
-        bitWrite(tempBools, 0, rumbleActive);
-    #endif // USES_RUMBLE
-    #ifdef USES_SOLENOID
-        bitWrite(tempBools, 1, solenoidActive);
-    #endif // USES_SOLENOID
-    bitWrite(tempBools, 2, autofireActive);
-    bitWrite(tempBools, 3, simpleMenu);
-    bitWrite(tempBools, 4, holdToPause);
-    #ifdef FOURPIN_LED
-        bitWrite(tempBools, 5, commonAnode);
-    #endif // FOURPIN_LED
+    if(!isLoad) {
+        #ifdef USES_RUMBLE
+            bitWrite(tempBools, 0, rumbleActive);
+        #endif // USES_RUMBLE
+        #ifdef USES_SOLENOID
+            bitWrite(tempBools, 1, solenoidActive);
+        #endif // USES_SOLENOID
+        bitWrite(tempBools, 2, autofireActive);
+        bitWrite(tempBools, 3, simpleMenu);
+        bitWrite(tempBools, 4, holdToPause);
+        #ifdef FOURPIN_LED
+            bitWrite(tempBools, 5, commonAnode);
+        #endif // FOURPIN_LED
+    }
 
     // Temp pin mappings
     int8_t tempMappings[] = {

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -178,7 +178,7 @@ int SamcoPreferences::SaveExtended(uint8_t *dataBools, int8_t *dataMappings, uin
 
 void SamcoPreferences::ResetPreferences()
 {
-    for(uint8_t i = 0; i < 255; ++i) {
+    for(uint16_t i = 0; i < EEPROM.length(); ++i) {
         EEPROM.write(i, 0);
     }
     #ifdef ARDUINO_ARCH_RP2040

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -6,8 +6,9 @@
  * @copyright GNU Lesser General Public License
  *
  * @author Mike Lynch
- * @version V1.0
- * @date 2021
+ * @author [That One Seong](SeongsSeongs@gmail.com)
+ * @version V1.1
+ * @date 2023
  */
 
 #include "SamcoPreferences.h"

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -13,7 +13,6 @@
 
 #include "SamcoPreferences.h"
 
-#include <Wire.h>
 #ifdef SAMCO_FLASH_ENABLE
 #include <Adafruit_SPIFlashBase.h>
 #endif // SAMCO_FLASH_ENABLE

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -153,11 +153,11 @@ void SamcoPreferences::LoadExtended(uint8_t *dataBools, int8_t *dataMappings, ui
 int SamcoPreferences::SaveExtended(uint8_t *dataBools, int8_t *dataMappings, uint16_t *dataSettings)
 {
     // Basic booleans
-    EEPROM.write(5 + (sizeof(ProfileData_t) * preferences.profileCount) + 1, *dataBools);
+    EEPROM.update(5 + (sizeof(ProfileData_t) * preferences.profileCount) + 1, *dataBools);
 
     // Custom Pins (always gets saved, regardless of if it's used or not)
     for(uint8_t i = 0; i < 27; ++i) {
-        EEPROM.write(5 + (sizeof(ProfileData_t) * preferences.profileCount) + 2 + i, *(dataMappings + i));
+        EEPROM.update(5 + (sizeof(ProfileData_t) * preferences.profileCount) + 2 + i, *(dataMappings + i));
     }
 
     // Main Settings

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -126,6 +126,85 @@ int SamcoPreferences::Save()
     return Error_Success;
 }
 
+void SamcoPreferences::LoadExtended(uint8_t *dataBools, int8_t *dataMappings, uint16_t *dataSettings)
+{
+    // Basic booleans
+    (*dataBools) = EEPROM.read(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools));
+
+    // Custom Pins (checks if this feature is enabled first, but space is always reserved)
+    (*dataMappings) = EEPROM.read(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools) + 1);
+    if(*dataMappings) { // dataMappings[0] corresponds to the custom pin bool.
+        for(uint8_t i = 1; i < sizeof(dataMappings); ++i) {
+            *(dataMappings + i) = EEPROM.read(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools) + 1 + i);
+        }
+    }
+
+    // Main Settings
+    uint16_t unsignedInt;
+    uint8_t n = 0;
+    for(uint8_t i = 0; i < (sizeof(dataSettings) / 2); ++i) {
+        *(dataSettings + i) = EEPROM.get(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools) + sizeof(dataMappings) + 1 + n, unsignedInt);
+        n += 2;
+    }
+    return;
+}
+
+// offset is: 5 + (sizeof(ProfileData_t) * preferences.profileCount)
+
+int SamcoPreferences::SaveExtended(uint8_t *dataBools, int8_t *dataMappings, uint16_t *dataSettings)
+{
+    // Basic booleans
+    EEPROM.write(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools), *dataBools);
+
+    // Custom Pins (always gets saved, regardless of if it's used or not)
+    for(uint8_t i = 0; i < sizeof(dataMappings); ++i) {
+        EEPROM.write(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools) + 1 + i, *(dataMappings + i));
+    }
+
+    // Main Settings
+    uint8_t n = 0;
+    for(uint8_t i = 0; i < (sizeof(dataSettings) / 2); ++i) {
+        uint16_t unsignedInt = *(dataSettings + i);
+        EEPROM.put(5 + (sizeof(ProfileData_t) * preferences.profileCount) + sizeof(*dataBools) + sizeof(dataMappings) + 1 + n, unsignedInt);
+        n += 2;
+    }
+
+    #ifdef ARDUINO_ARCH_RP2040
+        EEPROM.commit();
+    #endif // ARDUINO_ARCH_RP2040
+    return Error_Success;
+}
+
+void SamcoPreferences::ResetPreferences()
+{
+    for(uint8_t i = 0; i < 255; ++i) {
+        EEPROM.write(i, 0);
+    }
+    #ifdef ARDUINO_ARCH_RP2040
+        EEPROM.commit();
+    #endif // ARDUINO_ARCH_RP2040
+}
+
+
+#ifdef USE_TINYUSB
+int SamcoPreferences::LoadTinyID(char *tinyName, unsigned int *tinyID)
+{
+    *tinyName = EEPROM.get(EEPROM.length() - 18, *tinyName);
+    *tinyID = EEPROM.get(EEPROM.length() - 2, *tinyID);
+    return Error_Success;
+}
+
+int SamcoPreferences::SaveTinyID(char deviceName[16], unsigned int *tinyID)
+{
+    EEPROM.put(EEPROM.length() - 18, deviceName);
+    EEPROM.put(EEPROM.length() - 2, *tinyID);
+    #ifdef ARDUINO_ARCH_RP2040
+        EEPROM.commit();
+    #endif // ARDUINO_ARCH_RP2040
+    return Error_Success;
+}
+#endif // USE_TINYUSB
+
 #else
 
 int SamcoPreferences::Load()

--- a/SamcoEnhanced/SamcoPreferences.h
+++ b/SamcoEnhanced/SamcoPreferences.h
@@ -112,16 +112,6 @@ private:
     /// @return Nothing
     static void ResetPreferences();
 
-    #ifdef USE_TINYUSB
-    /// @brief Load TinyUSB identifiers
-    /// @return An error code from Errors_e
-    static int LoadTinyID(char *tinyName, unsigned int *tinyID);
-
-    /// @brief Save TinyID identifiers
-    /// @return An error code from Errors_e
-    static int SaveTinyID(char deviceName[16], unsigned int *tinyID);
-    #endif // USE_TINYUSB
-
 #endif
 };
 

--- a/SamcoEnhanced/SamcoPreferences.h
+++ b/SamcoEnhanced/SamcoPreferences.h
@@ -6,8 +6,9 @@
  * @copyright GNU Lesser General Public License
  *
  * @author Mike Lynch
- * @version V1.0
- * @date 2021
+ * @author [That One Seong](SeongsSeongs@gmail.com)
+ * @version V1.1
+ * @date 2023
  */
 
 #ifndef _SAMCOPREFERENCES_H_

--- a/SamcoEnhanced/SamcoPreferences.h
+++ b/SamcoEnhanced/SamcoPreferences.h
@@ -98,6 +98,29 @@ private:
     /// @brief Save preferences
     /// @return An error code from Errors_e
     static int Save();
+
+    /// @brief Load extended preferences
+    /// @return Nothing
+    static void LoadExtended(uint8_t *dataBools, int8_t *dataMappings, uint16_t *dataSettings);
+
+    /// @brief Save extended preferences
+    /// @return An error code from Errors_e
+    static int SaveExtended(uint8_t *dataBools, int8_t *dataMappings, uint16_t *dataSettings);
+
+    /// @brief Resets preferences with a zero-fill to the EEPROM.
+    /// @return Nothing
+    static void ResetPreferences();
+
+    #ifdef USE_TINYUSB
+    /// @brief Load TinyUSB identifiers
+    /// @return An error code from Errors_e
+    static int LoadTinyID(char *tinyName, unsigned int *tinyID);
+
+    /// @brief Save TinyID identifiers
+    /// @return An error code from Errors_e
+    static int SaveTinyID(char deviceName[16], unsigned int *tinyID);
+    #endif // USE_TINYUSB
+
 #endif
 };
 


### PR DESCRIPTION
This adds all the things necessary for complete save support; expanding data coverage to all the adjustable aspects of the gun--including *pin mapping,* toggleable booleans, other settings, and TinyUSB identifiers pulled from the EEPROM.

This also adds the backbone for remote board configuration using serial, under new categories:
 - `Xc` clears the EEPROM, which will be helpful for either initial boot or upgrading from either older builds or other projects that uses the virtual EEPROM provided by Earle Philhower's core.
 - `Xm` is used for updating the aforementioned gun settings using the `Xm.x.y.z` format, where;
   - `x` is the type of data being updated (0 = bools, 1 = pins, 2 = expanded preferences, 3 = tinyUSB ID stuff)
   - `y` is what data to update (what bool, what pin, what pref, which part of the tUSB ID)
   - `z` is the new value to assign to the data
   - Just typing `Xm` will print out exactly what's configurable, much like a Unix program's *--help* dialog.
 - `Xp` loads preferences from EEPROM into memory and prints it out in a neat table, mainly for debugging.
Expanded EEPROM stuff is saved along with the normal profiles using the typical `SavePreferences()` method, or can be called directly using the new function `ExtPreferences(false)` (boolean determines whether it's a save or load operation, to minimize code duplication).

For now, this does not cover flash saveram-based devices, causing builds to fail on anything but RP2040 - though since the project primarily targets Pi Pico and its derivatives, which doesn't use an external flash, it's well within board. If anyone wants to fix flash-enabled devices, all that needs to be done in theory is add/expand the flash extended save stuff in `SamcoPreferences.c/h`.

Quality of code isn't the cleanest, but has worked for my test devices.
Note that for TinyUSB identifiers, we handle that directly in the main `SamcoEnhanced.ino` sketch (currently in `TinyUSBInit()` method and the fourth tier of `Xm`-type settings in `SerialProcessing()`.
Variables that used to be bytes are now unsigned integers, to make saving/loading from EEPROM easier.

This also adds some miscellaneous fixes back into the main code, and formalizes Low Buttons Mode (a macro for making A/B turn into Start/Select when aimed offscreen).

Closes #18 